### PR TITLE
See if you like the change

### DIFF
--- a/ftplugin/python/coveragepy.vim
+++ b/ftplugin/python/coveragepy.vim
@@ -235,6 +235,7 @@ endfunction
 
 function! s:LastSession() abort
     call s:ClearAll()
+    let winnrback = bufwinnr(expand("%"))
     if (len(g:coveragepy_last_session) == 0)
         call s:CoveragepyReport()
     endif
@@ -254,7 +255,7 @@ function! s:LastSession() abort
     nnoremap <silent><script> <buffer> k       :call <sid>Roulette(-1)<CR>
     nnoremap <silent> <buffer> <Enter>         :call <sid>OpenBuffer()<CR>
     call s:CoveragepySyntax()
-    exe 'wincmd p'
+    exe winnrback  . 'wincmd w'
 endfunction
 
 


### PR DESCRIPTION
When running Vim with MinBufExplorer and running Coverage report, wincmd p in LastSession causes the cursor to jump to the navigation bar and then in HighlightsMissing, the line

```
let current_buffer = matchlist(expand("%:p"), '\v(.*)(.py)')[1]
```

ends up throwing an index error, because the list is empty. This change seems to fix it for me, see if you like it.

Signed-off-by: jzegan jzegan@gmail.com
