### PR TITLE
Excape backslashes in filepaths for regex matching

### DIFF
--- a/ftplugin/python/coveragepy.vim
+++ b/ftplugin/python/coveragepy.vim
@@ -108,7 +108,9 @@ function! s:HighlightMissing() abort
     let current_buffer = matchlist(expand("%:p"), '\v(.*)(.py)')[1]
 
     for path in keys(g:coveragepy_session_map)
-        if (current_buffer =~ path) || (current_buffer_py =~ path)
+        " escape path to use it as a regex pattern
+        let path_pattern = '\V' . escape(path, '\')
+        if (current_buffer =~ path_pattern) || (current_buffer_py =~ path_pattern)
             for position in g:coveragepy_session_map[path]
                 execute(":sign place ". position ." line=". position ." name=uncovered buffer=".bufnr("%"))
             endfor


### PR DESCRIPTION
Highlighting failed on Windows because the file paths contain backslashes. This
could potentially fail on *nix systems as well, if the paths contained
backslashes. Fixed by enabling very nomagic mode and escaping backslashes:
path_pattern = '\V' . escape(path, '\')