### PR TITLE
Use sign groups

### DIFF
--- a/ftplugin/python/coveragepy.vim
+++ b/ftplugin/python/coveragepy.vim
@@ -32,7 +32,6 @@ let g:coveragepy_last_session  = ""
 let g:coveragepy_marks         = []
 let g:coveragepy_session_map   = {}
 let g:coveragepy_executable    = ""
-let s:sign_id                  = 9423
 
 
 function! s:ToggleSigns()
@@ -87,16 +86,8 @@ endfunction
 
 
 function! s:ClearSigns() abort
-    let placements = split(execute('sign place file=' . bufname('%')), '\n')
-    let fname = bufname('%')
-    for s in placements
-      let cols = split(s)
-      let name = split(cols[-1], '=')[-1]
-      if name[0:8] ==# 'uncovered'
-        let id = s:sign_id
-        exe printf('sign unplace %d file=%s', id, fname)
-      endif
-    endfor
+    execute("sign unplace * group=uncovered buffer=".bufnr('%'))
+    execute("sign unplace * group=branchuncovered buffer=".bufnr('%'))
 endfunction
 
 
@@ -129,10 +120,10 @@ function! s:HighlightMissing() abort
     for path in keys(g:coveragepy_session_map)
         if (current_buffer =~ path) || (current_buffer_py =~ path)
             for position in g:coveragepy_session_map[path]
-                execute(":sign place ". s:sign_id ." line=". position ." name=uncovered buffer=".bufnr("%"))
+                execute(":sign place ". position ." line=". position ." group=uncovered name=uncovered buffer=".bufnr("%"))
             endfor
             for position in g:coveragepy_session_map['BRANCH' . path]
-                execute(":sign place ". s:sign_id ." line=". position ." name=branchuncovered buffer=".bufnr("%"))
+                execute(":sign place ". position ." line=". position ." group=branchuncovered name=branchuncovered buffer=".bufnr("%"))
             endfor
             " FIXME: I had to comment this out because it was no longer correct
             " after adding branch support


### PR DESCRIPTION
"Coveragepy noshow" and "... refresh" did have no effect for me.

Vim supports named group: <https://vimhelp.org/sign.txt.html>
Use them to group "[branch]uncovered" signs into them as it simplifies
clearing previous signs.

Switch "s:ClearSigns()" to use buffer number instead of file name.

This also makes https://github.com/alfredodeza/coveragepy.vim/pull/25 obsolete as it also clears the `branchuncovered` signs.